### PR TITLE
Enable 64 bit support

### DIFF
--- a/tests/int/test/integration/default/controls/webapps.rb
+++ b/tests/int/test/integration/default/controls/webapps.rb
@@ -12,6 +12,5 @@ control 'azure-webapp' do
     its('location') { should eq 'UK South' }
     its('default_host_name') { should eq "#{random_name.downcase}.app-compute-sandboxtestsupport.p.azurewebsites.net" }
     its('enabled_host_names') { should include "#{random_name.downcase}.scm.app-compute-sandboxtestsupport.p.azurewebsites.net" }
-    its('config.use32BitWorkerProcess') {should be false }
   end
 end


### PR DESCRIPTION
Enable 64 bit support by default. Make sure the worker process runs 64 bit