### PR TITLE
Slot app settings

### DIFF
--- a/templates/asp-app.json
+++ b/templates/asp-app.json
@@ -152,9 +152,9 @@
                 {
                   "name": "appsettings",
                   "type": "config",
-                  "apiVersion": "2016-08-01",
+                  "apiVersion": "2015-08-01",
                   "dependsOn": [
-                    "[concat('Microsoft.Web/sites/', parameters('name'))]"
+                    "[concat('Microsoft.Web/sites/', parameters('name'), '/slots/', parameters('stagingSlotName'))]"
                   ],
                   "tags": {
                     "displayName": "AppSettings"


### PR DESCRIPTION
Required so that staging slot has same environment variable settings as production slot.