### PR TITLE
Add resource_group_name output so that rg can be referenced

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -9,3 +9,7 @@ output "gitendpoint" {
 output "url" {
   value = "http://${azurerm_template_deployment.app_service_site.name}.service.internal"
 }
+
+output "resource_group_name" {
+  value = "${azurerm_resource_group.rg.name}"
+}


### PR DESCRIPTION
Need to reference the resource group name to create the vault in rhubarb. Currently, the name passed to the vault module is built through string concatenation which works only when the rg exists already. When building from scratch we need to force a dependency between the modules - the easiest way to do this is to output the rg name from this module and use the output in the vault module.