### PR TITLE
Allow for providing custom resource group name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,11 @@
+locals {
+  default_resource_group_name = "${var.product}-${var.env}"
+  resource_group_name = "${var.resource_group_name != "" ? var.resource_group_name : local.default_resource_group_name}"
+}
+
 # Create a resource group
 resource "azurerm_resource_group" "rg" {
-  name     = "${var.product}-${var.env}"
+  name     = "${local.resource_group_name}"
   location = "${var.location}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,12 @@ variable "staging_slot_name" {
 
 variable "ilbIp" {}
 
+variable "resource_group_name" {
+  type = "string"
+  default = ""
+  description = "Resource group name for the web application. If empty, the default will be set"
+}
+
 variable "application_type" {
   type = "string"
   default = "Web"


### PR DESCRIPTION
### Change description ###

Allow for providing custom resource group name via environment variable. Some resources have to exist before the web app is created (and need the resource group to be there already), so that they can pass their outputs (e.g. keys, connection strings, etc.) to it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
