### PR TITLE
Adds support for the MS Nodejs lib for App Insights

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,8 @@ resource "azurerm_application_insights" "appinsights" {
 locals {
   app_settings_evaluated = {
     APPLICATION_INSIGHTS_IKEY = "${azurerm_application_insights.appinsights.instrumentation_key}"
+    # Support for nodejs apps (java apps to migrate to this env var in future PR)
+    APPINSIGHTS_INSTRUMENTATIONKEY = "${azurerm_application_insights.appinsights.instrumentation_key}"
   }
 }
 


### PR DESCRIPTION
The java library currently uses `APPLICATION_INSIGHTS_IKEY`, however,
the underlying MS library also supports `APPINSIGHTS_INSTRUMENTATIONKEY`
so it makes sense to use just the single key which both libraries can
use.

A future PR will remove support for `APPLICATION_INSIGHTS_IKEY` once the
java libraries have been updated and client apps updated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
