### PR TITLE
Waf instance count

### DIFF
--- a/waf.tf
+++ b/waf.tf
@@ -1,7 +1,7 @@
 
 locals {
   prod_capacity = 2
-  capacity      = "${var.env != "prod" ? 1 : local.capacity}"
+  capacity      = "${var.env != "prod" ? 1 : local.prod_capacity}"
 }
 # Public ip for assigning to app gateway - Only created if var.is_frontend is set to true
 resource "azurerm_public_ip" "appGwPIP" {


### PR DESCRIPTION
Having two instances for each non-prod app is unnecessary and expensive. This change sets the capacity to 1 for nonprod envs.

tested here https://sandbox-build.platform.hmcts.net/job/Contino/job/moj-rhubarb-frontend/job/webapp_waf/3/console