### PR TITLE
Make resources implicitly dependent on resource group

### DIFF
--- a/waf.tf
+++ b/waf.tf
@@ -4,7 +4,7 @@ resource "azurerm_public_ip" "appGwPIP" {
   count                        = "${var.is_frontend}"
   name                         = "appGW-PIP"
   location                     = "${var.location}"
-  resource_group_name          = "${local.resource_group_name}"
+  resource_group_name          = "${azurerm_resource_group.rg.name}"
   public_ip_address_allocation = "dynamic"
 }
 
@@ -12,7 +12,7 @@ resource "azurerm_public_ip" "appGwPIP" {
 resource "azurerm_application_gateway" "waf" {
   count               = "${var.is_frontend}"
   name                = "${var.product}-${var.env}"
-  resource_group_name = "${local.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.rg.name}"
   location            = "${var.location}"
 
   sku {
@@ -20,24 +20,24 @@ resource "azurerm_application_gateway" "waf" {
     tier           = "WAF"
     capacity       = 2
   }
- 
+
   gateway_ip_configuration {
     name      = "appGatewayIpConfig"
     subnet_id = "${data.terraform_remote_state.core_infra.vnet_id}/subnets/${data.terraform_remote_state.core_infra.subnet_names[0]}"
   }
 
   frontend_port {
-    name = "http80" 
+    name = "http80"
     port = 80
   }
 
     frontend_port {
-    name = "http443" 
+    name = "http443"
     port = 443
   }
 
   frontend_ip_configuration {
-    name                 = "appGW-IP"  
+    name                 = "appGW-IP"
     public_ip_address_id = "${azurerm_public_ip.appGwPIP.id}"
   }
 
@@ -77,7 +77,7 @@ resource "azurerm_application_gateway" "waf" {
   #   frontend_port_name             = "http443"
   #   protocol                       = "Https"
   #   ssl_certificate_name           = "${var.env}"
-  # } 
+  # }
 
   request_routing_rule {
     name                       = "rule1"


### PR DESCRIPTION
Found an issue when doing a clean build of infra where there is no implicit dependency between the creation of the resource group and the waf leading to the following error where terraform tries to build them in parallel:

15:00:53 * azurerm_public_ip.appGwPIP: Error Creating/Updating Public IP "appGW-PIP" (Resource Group "rhubarb-frontend-sprod"): network.PublicIPAddressesClient#CreateOrUpdate: Failure sending request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceGroupNotFound" Message="Resource group 'rhubarb-frontend-sprod' could not be found."

### Change description ###

Updated resource_group_name attributes to be references to the actual resource so terraform knows to build the dependency first.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
