### PR TITLE
Changing the name of the ARM templates passed to the portal

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ locals {
 # Create Application Service site
 resource "azurerm_template_deployment" "app_service_site" {
   template_body       = "${data.template_file.sitetemplate.rendered}"
-  name                = "${var.product}-${var.env}"
+  name                = "${var.product}-${var.env}-webapp"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   deployment_mode     = "Incremental"
 

--- a/trafficman.tf
+++ b/trafficman.tf
@@ -4,7 +4,7 @@ data "template_file" "tmtemplate" {
 
 resource "azurerm_template_deployment" "tmprofile" {
   template_body       = "${data.template_file.tmtemplate.rendered}"
-  name                = "${var.product}-${var.env}"
+  name                = "${var.product}-${var.env}-tmprofile"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   deployment_mode     = "Incremental"
 


### PR DESCRIPTION
The current webapp creates two templates to be deployed into Azure. Currently they have the same name which means that it's impossible to troubleshoot int he portal as they get overwritten. I've added a suffix to each of the template names in TF to identify them in the portal.

As the name of the resource has changed in TF, it will delete the deployment in the portal. Please note that this WILL NOT delete the resources associated with the deployment.

Before :
![image](https://user-images.githubusercontent.com/21193823/37971721-8d3df4ba-31ce-11e8-9ba0-359ccff99e7e.png)

After:
![image](https://user-images.githubusercontent.com/21193823/37971689-79bfe344-31ce-11e8-8ba8-08c46d0a2038.png)

![image](https://user-images.githubusercontent.com/21193823/37971667-6e4995a0-31ce-11e8-98af-f5a9b395c997.png)


