### PR TITLE
Use https and port 443 for traffic manager health

### DIFF
--- a/templates/trafficmanager.json
+++ b/templates/trafficmanager.json
@@ -32,8 +32,8 @@
                     "ttl": 100
                 },
                 "monitorConfig": {
-                    "protocol": "HTTP",
-                    "port": 80,
+                    "protocol": "HTTPS",
+                    "port": 443,
                     "path": "/health",
                     "intervalInSeconds": 30,
                     "toleratedNumberOfFailures": 3,


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/ROC-3353


### Change description ###
Force https is set for frontend applications, health probes require a 200 status, they were getting redirected before I manually changed the health probe setting to test

This also saves having to setup tm http listeners and rules for each team...



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
