### PR TITLE
Increasing probe timeouts to 15 seconds

### DIFF
--- a/templates/trafficmanager.json
+++ b/templates/trafficmanager.json
@@ -37,7 +37,7 @@
                     "path": "/health",
                     "intervalInSeconds": 30,
                     "toleratedNumberOfFailures": 3,
-                    "timeoutInSeconds": 10
+                    "timeoutInSeconds": 15
                 },
                 "endpoints": [
                     {


### PR DESCRIPTION
The /health endpoints have a timeout of 15 seconds meaning that the TM Probe could fail before the endpoint has returned a response.

