### PR TITLE
Force capacity = 1 for preview builds

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "azurerm_template_deployment" "app_service_site" {
     additional_host_name = "${var.additional_host_name}"
     stagingSlotName      = "${var.staging_slot_name}"
     https_only           = "${var.https_only}"
-    capacity             = "${var.capacity}"
+    capacity             = "${var.env == "preview" ? "1" : var.capacity}"
     is_frontend          = "${var.is_frontend}"
     web_sockets_enabled  = "${var.web_sockets_enabled}"
     asp_name             = "${var.asp_name}-${var.env}"


### PR DESCRIPTION
### Change description ###
Force capacity to one for preview env:
https://build.platform.hmcts.net/job/HMCTS/job/cmc-claim-store/job/PR-363/1/consoleFull
Tested here:
```
08:15:39   parameters.asp_name:             "" => "null-preview"
08:15:39   parameters.capacity:             "" => "1"
08:15:39   parameters.env:                  "" => "preview"
08:15:39   parameters.https_only:           "" => "false"
08:15:39   parameters.is_frontend:          "" => "0"
08:15:39   parameters.location:             "" => "UK South"
08:15:39   parameters.name:                 "" => "pr-363-cmc-claim-store-preview"
08:15:39   parameters.stagingSlotName:      "" => "staging"
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
