### PR TITLE
add deployment tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ resource "azurerm_template_deployment" "app_service_site" {
     staging_app_settings = "${jsonencode(merge(var.staging_slot_app_settings, var.app_settings_defaults, local.app_settings_evaluated, var.app_settings))}"
     additional_host_name = "${var.additional_host_name}"
     stagingSlotName      = "${var.staging_slot_name}"
+    deploymentTag        = "${var.deploymentTag}"
     https_only           = "${var.https_only}"
     web_sockets_enabled  = "${var.web_sockets_enabled}"
     asp_id               = "${var.asp_id}"

--- a/templates/appservice.json
+++ b/templates/appservice.json
@@ -59,6 +59,12 @@
     },
     "asp_id": {
       "type": "string"
+    },
+    "deploymentTag": {
+      "type": "string",
+      "metadata": {
+        "description": "This tag is used to decide what component of the code should be deployed on it"
+      }
     }
   },
   "variables": {
@@ -74,7 +80,8 @@
       "tags": {
         "[concat('hidden-related:', parameters('asp_id'))]": "Resource",
         "displayName": "ASE-WEB-APP",
-        "environment": "[parameters('env')]"
+        "environment": "[parameters('env')]",
+        "deploymentTag": "[parameters('deploymentTag')]"
       },
       "dependsOn": [],
       "properties": {

--- a/variables.tf
+++ b/variables.tf
@@ -130,3 +130,8 @@ variable "asp_id" {}
 variable "subscription" {}
 
 variable "ilbIp" {}
+
+variable "deploymentTag" {
+  type    = "string"
+  default = "null"
+}


### PR DESCRIPTION
this adds a parameter (default is null) for developer to be able to define an app category or deployment category so when code is targeted for that tag all webapp infra resources with that tag inside a resource group will get that code deployed