### PR TITLE
Adds tag for last updated timestamp

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,8 @@ resource "azurerm_resource_group" "rg" {
   location = "${var.location}"
 
   tags {
-    environment = "${var.env}"
+    environment = "${var.env}",
+    lastUpdated = "${timestamp()}"
   }
 }
 


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CNP-598

### Change description ###
Adds a timestamp of when the terraform apply was last run against this resource group.  The value will be updated with each deploy.

Tested with Rhubarb backend here: https://build.platform.hmcts.net/job/HMCTS/job/moj-rhubarb-recipes-service/job/PR-70/

    15:49:18 ------------------------------------------------------------------------
    15:49:20 
    15:49:20 An execution plan has been generated and is shown below.
    15:49:20 Resource actions are indicated with the following symbols:
    15:49:20   ~ update in-place
    15:49:20 
    15:49:20 Terraform will perform the following actions:
    15:49:20 
    15:49:20   ~ module.recipe-backend.azurerm_resource_group.rg
    15:49:20       tags.lastUpdated: "2018-06-11T14:23:05Z" => "2018-06-11T14:49:20Z"
    15:49:20 
    15:49:20 
    15:49:20 Plan: 0 to add, 1 to change, 0 to destroy.
    15:49:20 
    15:49:20 ------------------------------------------------------------------------

![lastupdated](https://user-images.githubusercontent.com/362037/41240428-60db857c-6d92-11e8-9d65-49280a3cc9d0.PNG)
![lastupdated1](https://user-images.githubusercontent.com/362037/41240438-63feb2f6-6d92-11e8-87c1-7510d6d74dc0.PNG)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
