### PR TITLE
SIDM-1439: Adding lifecycle ignore to stop terraform nuking SSL

### DIFF
--- a/waf.tf
+++ b/waf.tf
@@ -13,6 +13,10 @@ resource "azurerm_application_gateway" "waf" {
   name                = "${var.product}-${var.env}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   location            = "${var.location}"
+  
+  lifecycle {
+    ignore_changes = ["http_listener", "request_routing_rule"]
+  }
 
   sku {
     name     = "WAF_Medium"


### PR DESCRIPTION
To prevent terraform nuking the required manual SSL changes, adding lifecycle
ignore_changes to http_listener and request_routing_rule


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
