### PR TITLE
Check asp_rg for null instead of asp_name

### DIFF
--- a/templates/asp-app.json
+++ b/templates/asp-app.json
@@ -88,7 +88,7 @@
     "base64SlotAppSettingObject": "[base64(parameters('staging_app_settings'))]",
     "trafficmanager": "[concat('hmcts-', parameters('name'),'.trafficmanager.net')]",
     "serverFarmName": "[if(contains(parameters('asp_name'), 'null'), parameters('name'), parameters('asp_name'))]",
-    "serverFarmRG": "[if(contains(parameters('asp_name'), 'null'),  parameters('name'), parameters('asp_rg'))]",
+    "serverFarmRG": "[if(contains(parameters('asp_rg'), 'null'),  parameters('name'), parameters('asp_rg'))]",
     "serverFarmId": "[if(contains(parameters('asp_name'), 'null'), resourceId('Microsoft.Web/serverfarms', variables('serverFarmName')), resourceId(parameters('asp_rg'), 'Microsoft.Web/serverfarms', variables('serverFarmName')))]"
   },
   "resources": [


### PR DESCRIPTION
If asp_name was previously set and asp_rg isn't then it fails
![image](https://user-images.githubusercontent.com/21194782/45013274-742ff500-b012-11e8-913e-aabf42433c16.png)
