### PR TITLE
Bump default minimum node to 8.11.1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "app_settings_defaults" {
   type = "map"
 
   default = {
-    WEBSITE_NODE_DEFAULT_VERSION                     = "8.9.4"
+    WEBSITE_NODE_DEFAULT_VERSION                     = "8.11.1"
     NODE_PATH                                        = "D:\\home\\site\\wwwroot"
     WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION = "0"
   }


### PR DESCRIPTION
Set default node to the highest available LTS Node 8 available on Azure.










**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```