### PR TITLE
Revert "Additional hostnames"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Name | Type |  Required | Default | description
 `app_settings` | String | Yes | | this is the key valued pairs of application settings used by the application at runtime
 `is_frontend` | Boolean | No | False | Indicates that this app could be routable from the public internet
 `additional_host_name` | String | No | | A custom domain name for your web application
-`additional_host_names` | List | No | | A list of custom domains for your web application
 `https_only` | String | No | `"false"` | Configures a web site to accept only https requests. Issues redirect for http requests. NB this is a string value that accepts values "true" or "false" - the string type is required to work around issues with Terraform and ARM template handling of boolean value.
 `waf_backend_ip` | String | No | IP of ILB for the ASE | Overrides the backend IP for the WAF to use instead of the ILB for the ASE. Only override if needed via an `{env}.tfvars` file
 `common_tags` | Map | Yes | | tags that need to be applied to every resource group, passed through by the jenkins-library
@@ -45,7 +44,6 @@ module "frontend" {
 	asp_rg       = "${var.product}-shared-infrastructure-${var.env}"
 	subscription = "${var.subscription}"
 	common_tags  = "${var.common_tags}"
-	additional_host_names = ["example.com","example.co.uk"]
 	app_settings = {
 		WEBSITE_NODE_DEFAULT_VERSION = "8.8.0"
 	}

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,6 @@ resource "azurerm_template_deployment" "app_service_site" {
     env                  = "${var.env}"
     app_settings         = "${jsonencode(merge(local.production_slot_app_settings, var.app_settings_defaults, local.app_settings_evaluated, var.app_settings))}"
     staging_app_settings = "${jsonencode(merge(var.staging_slot_app_settings, var.app_settings_defaults, local.app_settings_evaluated, var.app_settings))}"
-    additional_host_names = "${join(",", var.additional_host_names)}"
     additional_host_name = "${var.additional_host_name}"
     stagingSlotName      = "${var.staging_slot_name}"
     is_frontend          = "${var.is_frontend}"

--- a/templates/asp-app.json
+++ b/templates/asp-app.json
@@ -12,15 +12,12 @@
       "defaultValue": "0",
       "type": "string"
     },
-    "additional_host_names": {
+    "additional_host_name": {
       "type": "string",
+      "defaultValue": "example",
       "metadata": {
         "description": "The hostname this application should be accessible on"
       }
-    },
-    "additional_host_name":{
-      "type": "string",
-      "defaultValue": "null"
     },
     "location": {
       "type": "string",
@@ -95,8 +92,7 @@
     "base64AppSettingObject": "[base64(parameters('app_settings'))]",
     "base64SlotAppSettingObject": "[base64(parameters('staging_app_settings'))]",
     "trafficmanager": "[concat('hmcts-', parameters('name'),'.trafficmanager.net')]",
-    "serverFarmId": "[ResourceId(parameters('asp_rg'),'Microsoft.Web/serverfarms', parameters('asp_name'))]",
-    "additional_host_names": "[split(parameters('additional_host_names'),',')]"
+    "serverFarmId": "[ResourceId(parameters('asp_rg'),'Microsoft.Web/serverfarms', parameters('asp_name'))]"
   },
   "resources": [
     {
@@ -169,7 +165,7 @@
       "resources": [
         {
           "name": "[concat('tm', parameters('additional_host_name'))]",
-          "condition": "[not(equals(parameters('additional_host_name'), 'null'))]",
+          "condition": "[not(equals(parameters('is_frontend'), '0'))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",
@@ -184,7 +180,7 @@
         },
         {
           "name": "[parameters('additional_host_name')]",
-          "condition": "[not(equals(parameters('additional_host_name'), 'null'))]",
+          "condition": "[not(equals(parameters('is_frontend'), '0'))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",
@@ -196,6 +192,22 @@
           "dependsOn": [
             "[parameters('name')]",
             "[concat('tm', parameters('additional_host_name'))]"
+          ]
+        },
+        {
+          "name": "[variables('trafficmanager')]",
+          "condition": "[not(equals(parameters('is_frontend'), '0'))]",
+          "type": "hostNameBindings",
+          "apiVersion": "2016-08-01",
+          "location": "[parameters('location')]",
+          "tags": {},
+          "properties": {
+            "siteName": "[variables('trafficmanager')]",
+            "hostNameType": "Verified"
+          },
+          "dependsOn": [
+            "[parameters('name')]",
+            "[parameters('additional_host_name')]"
           ]
         },
         {
@@ -231,25 +243,6 @@
         }
       ]
     },
-    {
-      "name": "[concat(parameters('name'), '/', variables('additional_host_names')[copyIndex()])]",
-      "condition": "[not(equals(parameters('additional_host_names'), 'null'))]",
-      "type": "Microsoft.Web/sites/hostNameBindings",
-      "apiVersion": "2016-08-01",
-      "location": "[parameters('location')]",
-      "tags": {},
-      "properties": {
-        "siteName": "[variables('additional_host_names')[copyIndex()]]",
-        "hostNameType": "Verified"
-      },
-      "copy": {
-        "name" : "hostnamecopy",
-        "count": "[length(variables('additional_host_names'))]"
-      },
-      "dependsOn": [
-        "[concat('Microsoft.Web/sites/', parameters('Name'))]"
-      ]
-    },    
     {
       "apiVersion": "2016-08-01",
       "name": "[concat(parameters('name'), '/', parameters('stagingSlotName'))]",

--- a/variables.tf
+++ b/variables.tf
@@ -149,8 +149,3 @@ variable "is_frontend" {
   description = "if set to true, tf will create a WAF enabled application gateway"
   default = "0"
 }
-
-variable "additional_host_names" {
-  type = "list"
-  default = ["null"]
-}


### PR DESCRIPTION
Reverts hmcts/cnp-module-webapp#128

Broke our builds:
https://build.platform.hmcts.net/view/Platform/job/HMCTS_Platform/job/bulk-scan-orchestrator/view/change-requests/job/PR-111/12/console

```
08:02:18 * azurerm_template_deployment.app_service_site: Error creating deployment: resources.DeploymentsClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidTemplate" Message="Deployment template validation failed: 'The resource 'Microsoft.Web/sites/pr-111-bulk-scan-orchestrator-preview/hostNameBindings/null' at line '1' and column '3536' is defined multiple times in a template. Please see https://aka.ms/arm-template/#resources for usage details.'."
08:02:18 
```