### PR TITLE
Ignore SSL config when rebuilding WAF resources

### DIFF
--- a/waf.tf
+++ b/waf.tf
@@ -25,7 +25,7 @@ resource "azurerm_application_gateway" "waf" {
 #    )}"
 
   lifecycle {
-    ignore_changes = ["http_listener", "request_routing_rule", "probe", "backend_http_settings"]
+    ignore_changes = ["http_listener", "request_routing_rule", "probe", "backend_http_settings","ssl_certificate"]
   }
 
   sku {

--- a/waf.tf
+++ b/waf.tf
@@ -25,7 +25,7 @@ resource "azurerm_application_gateway" "waf" {
 #    )}"
 
   lifecycle {
-    ignore_changes = ["http_listener", "request_routing_rule", "probe", "backend_http_settings","ssl_certificate"]
+    ignore_changes = ["http_listener", "request_routing_rule", "probe", "backend_http_settings","ssl_certificate","authentication_certificate"]
   }
 
   sku {


### PR DESCRIPTION
### Change description ###
The WAF module in this version does not support SSL configuration. As a workaround - ignore any configs existing in the webapp state.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
