### PR TITLE
shared_infra var added

### DIFF
--- a/trafficman.tf
+++ b/trafficman.tf
@@ -7,6 +7,7 @@ resource "azurerm_template_deployment" "tmprofile" {
   name                = "${var.product}-${var.env}-tm"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   deployment_mode     = "Incremental"
+  count = "${var.shared_infra ? 0 : 1}"
 
   parameters = {
     name                 = "${var.product}-${var.env}"

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,9 @@ variable "is_frontend" {
   description = "if set to true, tf will create a WAF enabled application gateway"
   default = "0"
 }
+
+
+variable "shared_infra" {
+  description = "if set to true, tf will not create the TM profile"
+  default = false
+}


### PR DESCRIPTION
Added the shared_infra optional boolean parameter:  True means TF will not create the TM profile. The default value is False for backward compatibility.