### PR TITLE
App Insights is now available in UK South

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Name | Type |  Required | Default | description
 `source` | String | Yes | | this is the location source for the moj-module-webapp, the example implies a github repo containing the moj-module-webapp source
 `product` | String | Yes | | this is the name of the product or project i.e. probate, divorce etc.
 `location` | String | No | UK South | this is the azure region for this service
+`appinsights_location` | String | No | West Europe | the Azure region for App Insights instance, previously limited to 'West Europe' but now avaiable in 'UK South'.  Current default is kept simply to prevent data loss.  New instances should set 'UK South'.
 `env` | String | Yes | | this is used to differentiate the environments e.g dev, prod, test etc
 `app_settings` | String | Yes | | this is the key valued pairs of application settings used by the application at runtime
 `is_frontend` | Boolean | No | False | Indicates that this app could be routable from the public internet

--- a/README.md
+++ b/README.md
@@ -34,17 +34,18 @@ Following is an example of provisioning a NodeJs, SpringBoot, and Java enabled w
 
 ```terraform
 module "frontend" {
-	source       = "git@github.com:contino/cnp-module-webapp?ref=master"
-	product      = "${var.product}-frontend"
-	location     = "${var.location}"
-	env          = "${var.env}"
-	capacity     = "${var.capacity}"
-	is_frontend  = true
-	asp_name     = "${var.product}-${var.env}"
-	asp_rg       = "${var.product}-shared-infrastructure-${var.env}"
-	subscription = "${var.subscription}"
-	common_tags  = "${var.common_tags}"
-	app_settings = {
+	source               = "git@github.com:contino/cnp-module-webapp?ref=master"
+	product              = "${var.product}-frontend"
+	location             = "${var.location}"
+	appinsights_location = "${var.location}"
+	env                  = "${var.env}"
+	capacity             = "${var.capacity}"
+	is_frontend          = true
+	asp_name             = "${var.product}-${var.env}"
+	asp_rg               = "${var.product}-shared-infrastructure-${var.env}"
+	subscription         = "${var.subscription}"
+	common_tags          = "${var.common_tags}"
+	app_settings         = {
 		WEBSITE_NODE_DEFAULT_VERSION = "8.8.0"
 	}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "location" {
   default = "UK South"
 }
 
-// as of now, UK South is unavailable for Application Insights
+// previously, UK South was unavailable for Application Insights, keep default to prevent uneeded App Insight migrations and data loss
 variable "appinsights_location" {
   type        = "string"
   default     = "West Europe"

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "location" {
   default = "UK South"
 }
 
-// previously, UK South was unavailable for Application Insights, keep default to prevent uneeded App Insight migrations and data loss
+// previously, UK South was unavailable for Application Insights, keep default to prevent unneeded App Insight migrations and data loss
 variable "appinsights_location" {
   type        = "string"
   default     = "West Europe"


### PR DESCRIPTION
See
https://azure.microsoft.com/en-us/updates/application-insights-is-available-in-uk-south/







The only concern I have would be that I suspect we will lose data held
in the previous app insight instance.
But this does mean we're storing this data in the UK.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```