### PR TITLE
Added new  variable for migration to App insights spring starter to avoid remapping across all apps

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,8 @@ locals {
 
     # Support for nodejs apps (java apps to migrate to this env var in future PR)
     APPINSIGHTS_INSTRUMENTATIONKEY = "${local.effective_app_insights_instrumentation_key}"
+    # Added for migration to spring starter for App Insights module to avoid any re-mapping across all apps.
+    AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY = "${local.effective_app_insights_instrumentation_key}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ locals {
 
     # Support for nodejs apps (java apps to migrate to this env var in future PR)
     APPINSIGHTS_INSTRUMENTATIONKEY = "${local.effective_app_insights_instrumentation_key}"
-    # Added for migration to spring starter for App Insights module to avoid any re-mapping across all apps.
+    # Value used in the spring boot starter.
     AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY = "${local.effective_app_insights_instrumentation_key}"
   }
 }


### PR DESCRIPTION
Added new  variable for migration to App insights spring starter to avoid remapping across all apps

### JIRA link ###

https://tools.hmcts.net/jira/browse/RPE-879

### Change description ###

Added new  variable for migration to App insights spring starter to avoid remapping across all apps


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
