### PR TITLE
Allow setting custom domains for backend services

### DIFF
--- a/templates/asp-app.json
+++ b/templates/asp-app.json
@@ -174,7 +174,7 @@
       "resources": [
         {
           "name": "[concat('tm', parameters('additional_host_name'))]",
-          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost'), parameters('additional_host_name')))]",
+          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost', 'debugparam'), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",
@@ -189,7 +189,7 @@
         },
         {
           "name": "[parameters('additional_host_name')]",
-          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost'), parameters('additional_host_name')))]",
+          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost', 'debugparam'), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",
@@ -205,7 +205,7 @@
         },
         {
           "name": "[variables('trafficmanager')]",
-          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost'), parameters('additional_host_name')))]",
+          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost', 'debugparam'), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",

--- a/templates/asp-app.json
+++ b/templates/asp-app.json
@@ -174,7 +174,7 @@
       "resources": [
         {
           "name": "[concat('tm', parameters('additional_host_name'))]",
-          "condition": "[not(equals(parameters('is_frontend'), '0'))]",
+          "condition": "[not(contains(createArray('null', 'false', ''), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",
@@ -189,7 +189,7 @@
         },
         {
           "name": "[parameters('additional_host_name')]",
-          "condition": "[not(equals(parameters('is_frontend'), '0'))]",
+          "condition": "[not(contains(createArray('null', 'false', ''), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",
@@ -205,7 +205,7 @@
         },
         {
           "name": "[variables('trafficmanager')]",
-          "condition": "[not(equals(parameters('is_frontend'), '0'))]",
+          "condition": "[not(contains(createArray('null', 'false', ''), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",

--- a/templates/asp-app.json
+++ b/templates/asp-app.json
@@ -174,7 +174,7 @@
       "resources": [
         {
           "name": "[concat('tm', parameters('additional_host_name'))]",
-          "condition": "[not(contains(createArray('null', 'false', ''), parameters('additional_host_name')))]",
+          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost'), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",
@@ -189,7 +189,7 @@
         },
         {
           "name": "[parameters('additional_host_name')]",
-          "condition": "[not(contains(createArray('null', 'false', ''), parameters('additional_host_name')))]",
+          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost'), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",
@@ -205,7 +205,7 @@
         },
         {
           "name": "[variables('trafficmanager')]",
-          "condition": "[not(contains(createArray('null', 'false', ''), parameters('additional_host_name')))]",
+          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost'), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",

--- a/templates/asp-app.json
+++ b/templates/asp-app.json
@@ -174,7 +174,7 @@
       "resources": [
         {
           "name": "[concat('tm', parameters('additional_host_name'))]",
-          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost', 'debugparam'), parameters('additional_host_name')))]",
+          "condition": "[not(contains(createArray('', 'null', 'false'), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",
@@ -189,7 +189,7 @@
         },
         {
           "name": "[parameters('additional_host_name')]",
-          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost', 'debugparam'), parameters('additional_host_name')))]",
+          "condition": "[not(contains(createArray('', 'null', 'false'), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",
@@ -205,7 +205,7 @@
         },
         {
           "name": "[variables('trafficmanager')]",
-          "condition": "[not(contains(createArray('', 'null', 'false', 'localhost', 'debugparam'), parameters('additional_host_name')))]",
+          "condition": "[not(contains(createArray('', 'null', 'false'), parameters('additional_host_name')))]",
           "type": "hostNameBindings",
           "apiVersion": "2016-08-01",
           "location": "[parameters('location')]",


### PR DESCRIPTION
### JIRA link ###
N/A


### Change description ###
Enabled setting a custom domain for non-frontend services.


Tested with
* webapp with `additional_host_name` set
https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/pr-271-idam-api-idam-preview/providers/Microsoft.Web/sites/pr-271-idam-api-idam-preview/appServices
* webapp with `additional_host_name` not set
https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/pr-272-idam-api-idam-preview/providers/Microsoft.Web/sites/pr-272-idam-api-idam-preview/appServices


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
