### PR TITLE
Allow SSL configuration at webapp level

### DIFF
--- a/templates/app-ssl.json
+++ b/templates/app-ssl.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "key_vault_id": {
+            "type": "string",
+            "metadata": {
+                "description": "Existing Key Vault resource Id with an access policy to allow Microsoft.Web RP to read Key Vault secrets (Checkout README.md for more information)"
+            }
+        },
+        "certificate_name": {
+            "type": "string",
+            "metadata": {
+                "description": "Key Vault Secret that contains a PFX certificate"
+            }
+        },
+        "name": {
+            "type": "string",
+            "metadata": {
+                "description": "Existing App name to use for creating SSL binding. This App should have the hostname assigned as a custom domain"
+            }
+        },
+        "hostname": {
+            "type": "string",
+            "metadata": {
+                "description": "Custom hostname for creating SSL binding. This hostname should already be assigned to the Web App"
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "asp_rg": {
+            "type": "string"
+        },
+        "asp_name": {
+            "type": "string"
+        }
+    },
+    "variables": {
+        "serverFarmId": "[resourceId(parameters('asp_rg'),'Microsoft.Web/serverfarms', parameters('asp_name'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Web/certificates",
+            "name": "[parameters('certificate_name')]",
+            "apiVersion": "2016-03-01",
+            "location": "[parameters('location')]",
+            "properties": {
+                "keyVaultId": "[parameters('key_vault_id')]",
+                "keyVaultSecretName": "[parameters('certificate_name')]",
+                "serverFarmId": "[variables('serverFarmId')]"
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites",
+            "name": "[parameters('name')]",
+            "apiVersion": "2016-03-01",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/certificates', parameters('certificate_name'))]"
+            ],
+            "properties": {
+                "name": "[parameters('name')]",
+                "hostNameSslStates": [
+                    {
+                        "name": "[parameters('hostname')]",
+                        "sslState": "SniEnabled",
+                        "thumbprint": "[reference(resourceId('Microsoft.Web/certificates', parameters('certificate_name'))).Thumbprint]",
+                        "toUpdate": true
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -155,3 +155,11 @@ variable "java_container_version" {
   default     = "8.0"
   description = "See the portal for the available versions, 8.0 or 9.0 mean latest in their respective series (autoupdate)"
 }
+
+variable "certificate_key_vault_id" {
+  default = ""
+}
+
+variable "certificate_name" {
+  default = ""
+}


### PR DESCRIPTION
### JIRA link ###
-


### Change description ###
Allows configuration of an SSL certificate to an app service

Needs a separate ARM template because the SSL binding needs the custom hostname to have been created, but its created as a sub resource currently, also it needed a dependsOn for the certificate resource being created before the webapp but the certificate resource is only created when required.

A separate ARM template makes it a lot easier to conditionally create the resources, seems fine to me unless there's any ARM template experts here who can advise on a better way of doing it?

This has been tested locally on a webapp I created, will test it fully with IDAM before merge


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
