### PR TITLE
SIDM-3089 Fix first time execution errors: 'ResourceGroupNotFound' & ''Cannot find ServerFarm'

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,18 @@
+# Example CNP-Module-WebApp
+
+## Description
+
+This is an example implementation of the module that should be used for reference and local testing.
+
+## Usage
+
+```bash
+terraform plan -var "subscription_id=<id>" \
+               -var "subscription=<name>" \
+               -out=plan.tfplan
+
+terraform apply plan.tfplan
+
+terraform destroy -var "subscription_id=<id>" \
+                  -var "subscription=<name>"
+```

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -29,7 +29,12 @@ variable "common_tags" {
   }
 }
 
-module "frontend" {
+# Both default_asp_name_and_rg and params_asp_name_and_rg must be included to 
+# ensure that the dependencies and references work correctly in both examples.
+# A common error is to include a new dependsOn resourceId without the RG
+# parameter, which will work for default_asp_name_and_rg but fail on
+# params_asp_name_and_rg.
+module "default_asp_name_and_rg" {
 	source               = "../"
 	product              = "${var.product}-frontend-example"
 	location             = "${var.location}"
@@ -40,6 +45,29 @@ module "frontend" {
 	asp_name             = "${var.product}-${var.env}"
 	subscription         = "${var.subscription}"
 	common_tags          = "${var.common_tags}"
+	
+	# asp_name = "idam-web-frontend-example-sandbox"
+  # asp_rg = "idam-web-frontend-example-sandbox"
+
+	app_settings         = {
+		WEBSITE_NODE_DEFAULT_VERSION = "8.8.0"
+	}
+}
+
+module "params_asp_name_and_rg" {
+	source               = "../"
+	product              = "${var.product}-backend-example"
+	location             = "${var.location}"
+	appinsights_location = "${var.location}"
+	env                  = "${var.env}"
+	capacity             = "${var.capacity}"
+	asp_name             = "${var.product}-${var.env}"
+	subscription         = "${var.subscription}"
+	common_tags          = "${var.common_tags}"
+	
+	asp_name = "idam-backend-example-sandbox"
+  asp_rg = "idam-backend-example-sandbox"
+
 	app_settings         = {
 		WEBSITE_NODE_DEFAULT_VERSION = "8.8.0"
 	}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,0 +1,46 @@
+provider "azurerm" {
+  version = "1.22.1"
+  subscription_id = "${var.subscription_id}"
+}
+variable "subscription" {}
+
+variable "subscription_id" {}
+
+variable "product" {
+  default = "idam"
+}
+
+variable "location" {
+  default = "UK South"
+}
+
+variable "env" {
+  default = "sandbox"
+}
+
+variable "capacity" {
+  default = "1"
+}
+
+
+variable "common_tags" {
+  default = {
+    "Team Name" = "IDAM"
+  }
+}
+
+module "frontend" {
+	source               = "../"
+	product              = "${var.product}-frontend-example"
+	location             = "${var.location}"
+	appinsights_location = "${var.location}"
+	env                  = "${var.env}"
+	capacity             = "${var.capacity}"
+	is_frontend          = true
+	asp_name             = "${var.product}-${var.env}"
+	subscription         = "${var.subscription}"
+	common_tags          = "${var.common_tags}"
+	app_settings         = {
+		WEBSITE_NODE_DEFAULT_VERSION = "8.8.0"
+	}
+}

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,12 @@ resource "azurerm_resource_group" "rg" {
   tags = "${merge(var.common_tags,
     map("lastUpdated", "${timestamp()}")
     )}"
+  
+  # On creation, resource group is not ready without delay.
+  provisioner "local-exec" {
+    command = "sleep 120"
+    on_failure = "continue"
+  }
 }
 
 resource "azurerm_resource_group" "rg2" {
@@ -34,6 +40,12 @@ resource "azurerm_resource_group" "rg2" {
   tags = "${merge(var.common_tags,
     map("lastUpdated", "${timestamp()}")
     )}"
+    
+  # On creation, resource group is not ready without delay.
+  provisioner "local-exec" {
+    command = "sleep 120"
+    on_failure = "continue"
+  }
 }
 
 # The ARM template that creates a web app and app service plan

--- a/templates/asp-app.json
+++ b/templates/asp-app.json
@@ -153,6 +153,9 @@
         "environment": "[parameters('env')]",
         "Team Name": "[parameters('teamName')]"
       },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', concat('aspDeploy-', parameters('asp_name')))]"
+      ],
       "properties": {
         "name": "[parameters('name')]",
         "serverFarmId": "[variables('serverFarmId')]",

--- a/templates/asp-app.json
+++ b/templates/asp-app.json
@@ -154,7 +154,7 @@
         "Team Name": "[parameters('teamName')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Resources/deployments', concat('aspDeploy-', parameters('asp_name')))]"
+        "[resourceId(parameters('asp_rg'), 'Microsoft.Resources/deployments', concat('aspDeploy-', parameters('asp_name')))]"
       ],
       "properties": {
         "name": "[parameters('name')]",

--- a/trafficman.tf
+++ b/trafficman.tf
@@ -5,7 +5,7 @@ data "template_file" "tmtemplate" {
 resource "azurerm_template_deployment" "tmprofile" {
   template_body       = "${data.template_file.tmtemplate.rendered}"
   name                = "${var.product}-${var.env}-tm"
-  resource_group_name = "${local.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.rg.name}"
   deployment_mode     = "Incremental"
   count               = "${var.shared_infra ? 0 : 1}"
 


### PR DESCRIPTION
### Change description ###

Pipelines using the cnp-module-webapps must run 3 times to pass.

During Terraform execution, two failures will always occur for first time deployments before a successful execution.

1. `Resource group <name> could not be found`
2. `Cannot find ServerFarm with name <name>`

This is due to incorrect dependencies. By using the resource reference instead of the local within the Terraform resources, this enforces implicit dependencies for the RG resolving `ResourceGroupNotFound` errors.

By adding the `dependsOn` statement for the serverfarm deployment in the ARM template, this removes the 'Cannot find ServerFarm with name <name>' error.

```bash
# Execution 1
Error: Error applying plan:
2 error(s) occurred:
* module.idam-web-admin.azurerm_template_deployment.tmprofile: 1 error(s) occurred:
* azurerm_template_deployment.tmprofile: Error creating deployment: resources.DeploymentsClient#CreateOrUpdate: Failure sending request: StatusCode=404 -- Original Error: Code="ResourceGroupNotFound" Message="Resource group '<name>' could not be found."

# Execution 2
Error: Error applying plan:
1 error(s) occurred:
* module.idam-web-admin.azurerm_template_deployment.app_service_site: 1 error(s) occurred:
* azurerm_template_deployment.app_service_site: Error waiting for deployment: Code="DeploymentFailed" Message="At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-debug for usage details." Details=[{"code":"NotFound","message":"{\r\n  \"Code\": \"NotFound\",\r\n  \"Message\": \"Cannot find ServerFarm with name <name>.\",\r\n  \"Target\": null,\r\n  \"Details\": [\r\n    {\r\n      \"Message\": \"Cannot find ServerFarm with name <name>.\"\r\n    },\r\n    {\r\n      \"Code\": \"NotFound\"\r\n    },\r\n    {\r\n      \"ErrorEntity\": {\r\n        \"ExtendedCode\": \"51004\",\r\n        \"MessageTemplate\": \"Cannot find {0} with name {1}.\",\r\n        \"Parameters\": [\r\n          \"ServerFarm\",\r\n          \"<name>\"\r\n        ],\r\n        \"Code\": \"NotFound\",\r\n        \"Message\": \"Cannot find ServerFarm with name <name>\"\r\n      }\r\n    }\r\n  ],\r\n  \"Innererror\": null\r\n}"}]
```

Resource groups should be created outside of the module declaration and passed into the module as a param but a conditional resource has been retained for backwards compatibility.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```


