### PR TITLE
fix(client_affinity_enabled): set type to string not bool

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -169,5 +169,5 @@ variable "enable_ase" {
 }
 
 variable "client_affinity_enabled" {
-  default = false
+  default = "false"
 }


### PR DESCRIPTION
### Change description ###

Default type for client_affinity_enabled should be string

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
