### PR TITLE
Revert "Tf 0.12.x compatibility"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,7 +130,7 @@ resource "azurerm_template_deployment" "app_service_ssl" {
 resource "null_resource" "azcli_exec" {
   count = "${var.enable_ase ? 0 : 1}"
 
-  triggers {
+  triggers = {
     force_run = "${timestamp()}"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ locals {
 
 # Create Application Service site
 resource "azurerm_template_deployment" "app_service_site" {
-  count               = "${var.enable_ase == true ? 1 : 0}"
+  count               = "${var.enable_ase}"
   template_body       = "${data.template_file.sitetemplate.rendered}"
   name                = "${var.product}-${var.env}${var.deployment_target}-webapp"
   resource_group_name = "${local.resource_group_name}"
@@ -130,7 +130,7 @@ resource "azurerm_template_deployment" "app_service_ssl" {
 resource "null_resource" "azcli_exec" {
   count = "${var.enable_ase ? 0 : 1}"
 
-  triggers = {
+  triggers {
     force_run = "${timestamp()}"
   }
 


### PR DESCRIPTION
Reverts hmcts/cnp-module-webapp#159

Temporary revert to fix issue with TF 0.11.x. `enable_ase` flag is not working correctly and ARM template resource (for the app service) is not built from clean state.

PR to follow to fix for both TF 0.11 and 0.12